### PR TITLE
Added missing help(process) cell in tutorial

### DIFF
--- a/01_introduction/03_molecular_dynamics.ipynb
+++ b/01_introduction/03_molecular_dynamics.ipynb
@@ -590,8 +590,24 @@
    "id": "confused-valuation",
    "metadata": {},
    "source": [
-    "It's possible to query many other thermodynamic records. What's available depends on type of protocol and the MD package that is used to run the protocol. To get more information, run:\n",
-    "\n",
+    "It's possible to query many other thermodynamic records. What's available depends on type of protocol and the MD package that is used to run the protocol. To get more information, run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e182e8f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(process)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68a5891a",
+   "metadata": {},
+   "source": [
     "N.B. Certain functionality is specific to the process in question, i.e. `BSS.Process.Amber` will have different options to `BSS.Process.Gromacs`, but, for the purposes of interoperability, there is a core set of functionality that is consistent across all `Process` classes, e.g. all classes implement a `getSystem` method.)\n",
     "\n",
     "### Plotting time series data\n",


### PR DESCRIPTION
In the introductory tutorial notebook, specifically in https://github.com/OpenBioSim/biosimspace_tutorials/blob/main/01_introduction/03_molecular_dynamics.ipynb there is a cell missing that should show user how to get more information on the `BioSimSpace.Process._amber` object after equilibration calculation was ran with Amber. Currently that cell reads:

> It's possible to query many other thermodynamic records. What's available depends on type of protocol and the MD package that is used to run the protocol. To get more information, run:
> 
> N.B. Certain functionality is specific to the process in question, i.e. BSS.Process.Amber will have different options to BSS.Process.Gromacs, but, for the purposes of interoperability, there is a core set of functionality that is consistent across all Process classes, e.g. all classes implement a getSystem method.)


This PR adds the missing `help(process)` code cell so that section now reads:

> It's possible to query many other thermodynamic records. What's available depends on type of protocol and the MD package that is used to run the protocol. To get more information, run:
>
>  `help(process)`
>
> N.B. Certain functionality is specific to the process in question, i.e. BSS.Process.Amber will have different options to BSS.Process.Gromacs, but, for the purposes of interoperability, there is a core set of functionality that is consistent across all Process classes, e.g. all classes implement a getSystem method.)

This addition is based on tutorial in the https://github.com/CCPBioSim/biosimspace-workshop/blob/master/01_introduction.ipynb notebook, where that `help(process)` cell is present but missing in https://github.com/michellab/BioSimSpaceTutorials/blob/main/01_introduction/03_molecular_dynamics.ipynb, which I assume is why it got carried over during the migration.
