### PR TITLE
Minor fix for RBFE/02_analysis_rbfe notebook

### DIFF
--- a/04_fep/02_RBFE/02_analysis_rbfe.ipynb
+++ b/04_fep/02_RBFE/02_analysis_rbfe.ipynb
@@ -646,9 +646,9 @@
    "source": [
     "network = wrangle.FEMap(f\"analysis/outputs/cinnabar_data.csv\")\n",
     "# plot the perturbations\n",
-    "plotting.plot_DDGs(network.graph, title=\"DDGs\", filename=f\"analysis/outputs/DDGs.png\")\n",
+    "plotting.plot_DDGs(network.graph, title=\"DDGs\", filename=f\"analysis/outputs/DDGs.png\", figsize=6)\n",
     "# plot the ligands\n",
-    "plotting.plot_DGs(network.graph, title=\"DGs\", filename=f\"analysis/outputs/DGs.png\")"
+    "plotting.plot_DGs(network.graph, title=\"DGs\", filename=f\"analysis/outputs/DGs.png\", figsize=6)"
    ]
   },
   {
@@ -878,9 +878,9 @@
     "\n",
     "network = wrangle.FEMap(f\"analysis/outputs/cinnabar_data_outliers_removed.csv\")\n",
     "# plot the perturbations\n",
-    "plotting.plot_DDGs(network.graph, title=\"DDGs\", filename=f\"analysis/outputs/DDGs_outliers_removed.png\")\n",
+    "plotting.plot_DDGs(network.graph, title=\"DDGs\", filename=f\"analysis/outputs/DDGs_outliers_removed.png\", figsize=6)\n",
     "# plot the ligands\n",
-    "plotting.plot_DGs(network.graph, title=\"DGs\", filename=f\"analysis/outputs/DGs_outliers_removed.png\")\n",
+    "plotting.plot_DGs(network.graph, title=\"DGs\", filename=f\"analysis/outputs/DGs_outliers_removed.png\", figsize=6)\n",
     "```\n",
     "\n",
     "</details>"
@@ -936,7 +936,7 @@
     "\n",
     "```python\n",
     "\n",
-    "BSS.Notebook.View(\"inputs/ligands/analysis_ligands/lig_jmc27.sdf\").system()\n",
+    "BSS.Notebook.View(\"inputs/ligands/analysis_ligands/jmc_27.sdf\").system()\n",
     "\n",
     "```\n",
     "</details>"

--- a/04_fep/02_RBFE/02_analysis_rbfe.md
+++ b/04_fep/02_RBFE/02_analysis_rbfe.md
@@ -541,9 +541,9 @@ Next, we can use this file to instatiate a FEMap object, that we can then use to
 ```python
 network = wrangle.FEMap(f"analysis/outputs/cinnabar_data.csv")
 # plot the perturbations
-plotting.plot_DDGs(network.graph, title="DDGs", filename=f"analysis/outputs/DDGs.png")
+plotting.plot_DDGs(network.graph, title="DDGs", filename=f"analysis/outputs/DDGs.png", figsize=6)
 # plot the ligands
-plotting.plot_DGs(network.graph, title="DGs", filename=f"analysis/outputs/DGs.png")
+plotting.plot_DGs(network.graph, title="DGs", filename=f"analysis/outputs/DGs.png", figsize=6)
 ```
 
 ### 2.1. Outliers
@@ -739,9 +739,9 @@ with open(f"analysis/outputs/cinnabar_data_outliers_removed.csv", "w") as cinnab
 
 network = wrangle.FEMap(f"analysis/outputs/cinnabar_data_outliers_removed.csv")
 # plot the perturbations
-plotting.plot_DDGs(network.graph, title="DDGs", filename=f"analysis/outputs/DDGs_outliers_removed.png")
+plotting.plot_DDGs(network.graph, title="DDGs", filename=f"analysis/outputs/DDGs_outliers_removed.png", figsize=6)
 # plot the ligands
-plotting.plot_DGs(network.graph, title="DGs", filename=f"analysis/outputs/DGs_outliers_removed.png")
+plotting.plot_DGs(network.graph, title="DGs", filename=f"analysis/outputs/DGs_outliers_removed.png", figsize=6)
 ```
 
 </details>
@@ -778,7 +778,7 @@ The best binder based on this data is 'lig_jmc27'. We can visualise this using B
 
 ```python
 
-BSS.Notebook.View("inputs/ligands/analysis_ligands/lig_jmc27.sdf").system()
+BSS.Notebook.View("inputs/ligands/analysis_ligands/jmc_27.sdf").system()
 
 ```
 </details>


### PR DESCRIPTION
This PR adds minor fixes for exercise 2.2.1 solution in https://github.com/OpenBioSim/biosimspace_tutorials/blob/main/04_fep/02_RBFE/02_analysis_rbfe.ipynb tutorial notebook. Currently exercise solution looks for non-existent ligand file (`"inputs/ligands/analysis_ligands/lig_jmc27.sdf"` file, but only `"inputs/ligands/analysis_ligands/jmc_27.sdf"` exists).

In addition, the size of cinnabar output plots is increased as they are currently squished and axes are not displayed properly.