### PR TITLE
Reduce Memory Usage of ABFE Setup Notebook

### DIFF
--- a/04_fep/03_ABFE/01_setup_abfe.ipynb
+++ b/04_fep/03_ABFE/01_setup_abfe.ipynb
@@ -531,7 +531,7 @@
     "\n",
     "The first off-diagonal terms are sufficiently large (much greater than the [empirical cut-off of 0.03](https://link.springer.com/article/10.1007/s10822-015-9840-9)), indicating good overlap and giving us some confidence that the MBAR estimate will be reliable.\n",
     "\n",
-    "Note that initially, the output directory does not contain \"restrain\" and \"discharge\" directories:"
+    "Note that initially, the output directory does not contain a \"restrain\" directory:"
    ]
   },
   {
@@ -562,31 +562,14 @@
     "    engine=\"somd\",\n",
     "    restraint=restraint,\n",
     "    work_dir=\"output/restrain\",\n",
-    ")\n",
-    "\n",
-    "# Set up discharging stage\n",
-    "# Note that a resonable set of lambda windows would be [0.000, 0.143, 0.286, 0.429, 0.571, 0.714, 0.857, 1.000]\n",
-    "# but we will use fewer windows to save memory.\n",
-    "lam_vals_discharge = [0.000, 0.500, 1.000]\n",
-    "discharge_protocol = BSS.Protocol.FreeEnergy(\n",
-    "    runtime=6 * BSS.Units.Time.nanosecond,\n",
-    "    lam_vals=lam_vals_discharge,\n",
-    "    perturbation_type=\"discharge_soft\",\n",
-    ")\n",
-    "discharge_fe_calc = BSS.FreeEnergy.AlchemicalFreeEnergy(\n",
-    "    restraint.system,\n",
-    "    discharge_protocol,\n",
-    "    engine=\"somd\",\n",
-    "    restraint=restraint,\n",
-    "    work_dir=\"output/discharge\",\n",
-    ")"
+    ")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "BioSimSpace has set up the required `work_dir`s for each stage of the calculation, and all the files needed to run the simulation should have been set up. Have a look!"
+    "BioSimSpace has set up the required `work_dir`s for the restrain stage, and all the files needed to run the simulation should have been set up. Have a look!"
    ]
   },
   {
@@ -602,21 +585,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We could run the simulations using:\n",
+    "We could run the restrain stage simulations using:\n",
     "\n",
     "```Python\n",
     "restrain_fe_calc.run()\n",
-    "discharge_fe_calc.run()\n",
     "```\n",
     "However, these would take hours to run, so we'll avoid starting them now.\n",
     "\n",
-    "Setting up calculations is quite memory-intensive. As we have limited resources on the server, we'll avoid setting up any more stages. Below are some examples of how to set up a vanishing stage, how to set up the free leg, and how to set up using GROMACS instead of SOMD.\n",
+    "Setting up calculations is quite memory-intensive. As we have limited resources on the server, we'll avoid setting up any more stages. Below are some examples of how to set up a the remaining stages for the bound leg (discharging and vanishing stages), how to set up the free leg, and how to set up using GROMACS instead of SOMD.\n",
     "\n",
     "<div class=\"alert alert-success\">\n",
-    "<b>Example: Setting up the vanish stage with a 1 fs timestep</b>\n",
+    "<b>Example: Setting up the bound leg discharge and vanish stages with a 1 fs timestep</b>\n",
     "</div>\n",
     "\n",
     "```Python\n",
+    "# Set up discharge stage\n",
+    "lam_vals_discharge = [0.000, 0.143, 0.286, 0.429, 0.571, 0.714, 0.857, 1.000]\n",
+    "\n",
+    "discharge_protocol = BSS.Protocol.FreeEnergy(\n",
+    "    runtime=6 * BSS.Units.Time.nanosecond,\n",
+    "    timestep=1*BSS.Units.Time.femtosecond, \n",
+    "    lam_vals=lam_vals_discharge,\n",
+    "    perturbation_type=\"discharge_soft\",\n",
+    ")\n",
+    "discharge_fe_calc = BSS.FreeEnergy.AlchemicalFreeEnergy(\n",
+    "    restraint.system,\n",
+    "    discharge_protocol,\n",
+    "    engine=\"somd\",\n",
+    "    restraint=restraint,\n",
+    "    work_dir=\"output/discharge\",\n",
+    ")\n",
+    "\n",
+    "# Set up vanish stage\n",
     "lam_vals_vanish = [0.000, 0.025, 0.050, 0.075, 0.100, 0.125, 0.150, 0.175, 0.200, # We need a lot of these to\n",
     "                   0.225, 0.250, 0.275, 0.300, 0.325, 0.350, 0.375, 0.400, 0.425, # ensure sufficient overlap\n",
     "                   0.450, 0.475, 0.500, 0.525, 0.550, 0.575, 0.600, 0.625, 0.650, # between windows!\n",

--- a/04_fep/03_ABFE/01_setup_abfe.ipynb
+++ b/04_fep/03_ABFE/01_setup_abfe.ipynb
@@ -565,7 +565,9 @@
     ")\n",
     "\n",
     "# Set up discharging stage\n",
-    "lam_vals_discharge = [0.000, 0.143, 0.286, 0.429, 0.571, 0.714, 0.857, 1.000]\n",
+    "# Note that a resonable set of lambda windows would be [0.000, 0.143, 0.286, 0.429, 0.571, 0.714, 0.857, 1.000]\n",
+    "# but we will use fewer windows to save memory.\n",
+    "lam_vals_discharge = [0.000, 0.500, 1.000]\n",
     "discharge_protocol = BSS.Protocol.FreeEnergy(\n",
     "    runtime=6 * BSS.Units.Time.nanosecond,\n",
     "    lam_vals=lam_vals_discharge,\n",
@@ -608,44 +610,17 @@
     "```\n",
     "However, these would take hours to run, so we'll avoid starting them now.\n",
     "\n",
-    "<div class=\"alert alert-success\">\n",
-    "<b>Exercise 4: Set Up the Vanish Stage Calculations</b>\n",
-    "</div>\n",
+    "Setting up calculations is quite memory-intensive. As we have limited resources on the server, we'll avoid setting up any more stages. Below are some examples of how to set up a vanishing stage, how to set up the free leg, and how to set up using GROMACS instead of SOMD.\n",
     "\n",
-    "Now it's your turn: complete the code below to set up the vanish stage calculations for the vanish stage, using SOMD and a 1 fs timestep. Note that a reasonable set of lambda values is:\n",
+    "<div class=\"alert alert-success\">\n",
+    "<b>Example: Setting up the vanish stage with a 1 fs timestep</b>\n",
+    "</div>\n",
     "\n",
     "```Python\n",
     "lam_vals_vanish = [0.000, 0.025, 0.050, 0.075, 0.100, 0.125, 0.150, 0.175, 0.200, # We need a lot of these to\n",
     "                   0.225, 0.250, 0.275, 0.300, 0.325, 0.350, 0.375, 0.400, 0.425, # ensure sufficient overlap\n",
     "                   0.450, 0.475, 0.500, 0.525, 0.550, 0.575, 0.600, 0.625, 0.650, # between windows!\n",
     "                   0.675, 0.700, 0.725, 0.750, 0.800, 0.850, 0.900, 0.950, 1.000] \n",
-    "```\n",
-    "However, will use an unrealistically small set of lambda values to avoid overloading the kernel."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set up the vanish stage\n",
-    "lam_vals_vanish = [\n",
-    "    0.000,\n",
-    "    0.500,\n",
-    "    1.000,\n",
-    "]  # Far too few lambda values - this calculation would\n",
-    "# not provide a reliable free energy estimate\n",
-    "# FIXME: Complete the code to set up the vanish stage calculations for SOMD with a 1 fs timestep"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<details><summary {style='color:green;font-weight:bold'}> Click here to see solution to Exercise. </summary>\n",
-    "\n",
-    "```python\n",
     "\n",
     "vanish_protocol = BSS.Protocol.FreeEnergy(runtime=6*BSS.Units.Time.nanosecond, \n",
     "                                          timestep=1*BSS.Units.Time.femtosecond, \n",
@@ -657,60 +632,14 @@
     "                                                     engine='somd', \n",
     "                                                     restraint=restraint, \n",
     "                                                     work_dir='output/vanish')\n",
-    "\n",
     "```\n",
-    "</details>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-success\">\n",
-    "<b>Exercise 5: Set up the Free Leg Simulations</b>\n",
-    "</div>\n",
     "\n",
-    "Of course, to obtain the overall free energy of binding we must perform the free leg calculations as well, where we discharge and vanish the ligand in a box of water. Set up the free leg simulations using BioSimSpace. You will find the equilibrated input files in input/free_ligand. Examples of realistic $\\mathrm{\\lambda}$ schedules are:\n",
+    "<div class=\"alert alert-success\">\n",
+    "<b>Example: Setting up the free leg</b>\n",
+    "</div>\n",
     "\n",
     "```Python\n",
     "lam_vals_discharge_free = [0.000, 0.143, 0.286, 0.429, 0.571, 0.714, 0.857, 1.000]\n",
-    "# Notice that far fewer lambda windows are required than for the bound vanish stage\n",
-    "lam_vals_vanish_free = [0.000, 0.028, 0.056, 0.111, 0.167, 0.222, 0.278, 0.333, 0.389, 0.444, \n",
-    "                        0.500, 0.556, 0.611, 0.667, 0.722, 0.778, 0.889, 1.000]\n",
-    "```\n",
-    "\n",
-    "But again, we will use far fewer to avoid overloading the kernel."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lam_vals_discharge_free = [\n",
-    "    0.000,\n",
-    "    0.5000,\n",
-    "    1.000,\n",
-    "]  # Far too few windows for actual calculation\n",
-    "lam_vals_vanish_free = [\n",
-    "    0.000,\n",
-    "    0.500,\n",
-    "    1.000,\n",
-    "]  # Far too few windows for actual calculation\n",
-    "\n",
-    "# FIXME: Set up the free leg simulations"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<details><summary {style='color:green;font-weight:bold'}> Click here to see solution to Exercise. </summary>\n",
-    "\n",
-    "```python\n",
-    "# Set up free discharge stage\n",
-    "lam_vals_discharge_free = [0.000, 0.5000, 1.000] # Far too few windows for actual calculation\n",
     "\n",
     "free_discharge_protocol = BSS.Protocol.FreeEnergy(runtime=6*BSS.Units.Time.nanosecond, \n",
     "                                                  lam_vals=lam_vals_discharge_free, \n",
@@ -722,8 +651,8 @@
     "                                                             restraint=restraint,\n",
     "                                                             work_dir='output/free_discharge')\n",
     "\n",
-    "# Set up the free vanish stage. Notice that far fewer lambda windows are required than for the bound vanish stage\n",
-    "lam_vals_vanish_free = [0.000, 0.500, 1.000] # Far too few windows for actual calculation\n",
+    "lam_vals_vanish_free = [0.000, 0.028, 0.056, 0.111, 0.167, 0.222, 0.278, 0.333, 0.389, 0.444, \n",
+    "                        0.500, 0.556, 0.611, 0.667, 0.722, 0.778, 0.889, 1.000]\n",
     "\n",
     "free_vanish_protocol = BSS.Protocol.FreeEnergy(runtime=6*BSS.Units.Time.nanosecond, \n",
     "                                               lam_vals=lam_vals_vanish_free,\n",
@@ -735,18 +664,12 @@
     "                                                          restraint=restraint,\n",
     "                                                          work_dir='output/free_vanish')\n",
     "```\n",
-    "</details>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "\n",
     "<div class=\"alert alert-success\">\n",
-    "<b>Exercise 6: Set up the Free Leg Simulations</b>\n",
+    "<b>Example: Setting up the bound leg with GROMACS</b>\n",
     "</div>\n",
     "\n",
-    "Repeat the set up of the bound calculations for GROMACS. Note that the perturbation type must be \"full\" (restraining, discharging and vanishing carried out in a single simulation) and the lambda values should be supplied as a pandas data frame (because GROMACS allows different lambda values to be specified simultaneously for each stage):\n",
+    "Note that the perturbation type must be \"full\" (restraining, discharging and vanishing carried out in a single simulation) and the lambda values should be supplied as a pandas data frame (because GROMACS allows different lambda values to be specified simultaneously for each stage):\n",
     "\n",
     "```Python\n",
     "lam_vals=pd.DataFrame(data={'bonded': [0.0, ... 1.0],\n",
@@ -776,33 +699,8 @@
     "                               0.8, 0.85, 0.9, 0.95, 1.0]}\n",
     "                         )\n",
     "```\n",
-    "But as usual, we will use fewer."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "# Use a reduced set of lambda values\n",
-    "gromacs_lam_vals = pd.DataFrame(\n",
-    "    data={\"bonded\": [0.0, 1.0, 1.0], \"coul\": [0.0, 1.0, 1.0], \"vdw\": [0.0, 0.5, 1.0]}\n",
-    ")\n",
-    "\n",
-    "# FIXME: Set up the bound simulations for GROMACS"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<details><summary {style='color:green;font-weight:bold'}> Click here to see solution to Exercise. </summary>\n",
-    "\n",
-    "```python\n",
-    "# The initial value of lambda\n",
+    "The code to set up the bound leg is then:\n",
+    "```Python\n",
     "initial_lam=pd.Series(data={'bonded': 0.0, 'coul': 0.0, 'vdw': 0.0})\n",
     "                         \n",
     "gromacs_protocol = BSS.Protocol.FreeEnergy(runtime=6*BSS.Units.Time.nanosecond, \n",
@@ -814,9 +712,7 @@
     "                                                      gromacs_protocol, \n",
     "                                                      engine='gromacs', restraint=restraint, \n",
     "                                                      work_dir='output/gromacs')\n",
-    "\n",
-    "```\n",
-    "</details>"
+    "```"
    ]
   },
   {
@@ -847,8 +743,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "pygments_lexer": "ipython3"
   },
   "vscode": {
    "interpreter": {

--- a/04_fep/03_ABFE/01_setup_abfe.md
+++ b/04_fep/03_ABFE/01_setup_abfe.md
@@ -347,7 +347,7 @@ An example overlap matrix (discharge stage of the bound leg) for the final set o
 
 The first off-diagonal terms are sufficiently large (much greater than the [empirical cut-off of 0.03](https://link.springer.com/article/10.1007/s10822-015-9840-9)), indicating good overlap and giving us some confidence that the MBAR estimate will be reliable.
 
-Note that initially, the output directory does not contain "restrain" and "discharge" directories:
+Note that initially, the output directory does not contain a "restrain" directory:
 
 
 ```python
@@ -371,12 +371,35 @@ restrain_fe_calc = BSS.FreeEnergy.AlchemicalFreeEnergy(
     work_dir="output/restrain",
 )
 
-# Set up discharging stage
-# Note that a resonable set of lambda windows would be [0.000, 0.143, 0.286, 0.429, 0.571, 0.714, 0.857, 1.000]
-# but we will use fewer windows to save memory.
-lam_vals_discharge = [0.000, 0.500, 1.000]
+```
+
+BioSimSpace has set up the required `work_dir`s for the restrain stage, and all the files needed to run the simulation should have been set up. Have a look!
+
+
+```python
+! ls output
+```
+
+We could run the restrain stage simulations using:
+
+```Python
+restrain_fe_calc.run()
+```
+However, these would take hours to run, so we'll avoid starting them now.
+
+Setting up calculations is quite memory-intensive. As we have limited resources on the server, we'll avoid setting up any more stages. Below are some examples of how to set up a the remaining stages for the bound leg (discharging and vanishing stages), how to set up the free leg, and how to set up using GROMACS instead of SOMD.
+
+<div class="alert alert-success">
+<b>Example: Setting up the bound leg discharge and vanish stages with a 1 fs timestep</b>
+</div>
+
+```Python
+# Set up discharge stage
+lam_vals_discharge = [0.000, 0.143, 0.286, 0.429, 0.571, 0.714, 0.857, 1.000]
+
 discharge_protocol = BSS.Protocol.FreeEnergy(
     runtime=6 * BSS.Units.Time.nanosecond,
+    timestep=1*BSS.Units.Time.femtosecond, 
     lam_vals=lam_vals_discharge,
     perturbation_type="discharge_soft",
 )
@@ -387,30 +410,8 @@ discharge_fe_calc = BSS.FreeEnergy.AlchemicalFreeEnergy(
     restraint=restraint,
     work_dir="output/discharge",
 )
-```
 
-BioSimSpace has set up the required `work_dir`s for each stage of the calculation, and all the files needed to run the simulation should have been set up. Have a look!
-
-
-```python
-! ls output
-```
-
-We could run the simulations using:
-
-```Python
-restrain_fe_calc.run()
-discharge_fe_calc.run()
-```
-However, these would take hours to run, so we'll avoid starting them now.
-
-Setting up calculations is quite memory-intensive. As we have limited resources on the server, we'll avoid setting up any more stages. Below are some examples of how to set up a vanishing stage, how to set up the free leg, and how to set up using GROMACS instead of SOMD.
-
-<div class="alert alert-success">
-<b>Example: Setting up the vanish stage with a 1 fs timestep</b>
-</div>
-
-```Python
+# Set up vanish stage
 lam_vals_vanish = [0.000, 0.025, 0.050, 0.075, 0.100, 0.125, 0.150, 0.175, 0.200, # We need a lot of these to
                    0.225, 0.250, 0.275, 0.300, 0.325, 0.350, 0.375, 0.400, 0.425, # ensure sufficient overlap
                    0.450, 0.475, 0.500, 0.525, 0.550, 0.575, 0.600, 0.625, 0.650, # between windows!


### PR DESCRIPTION
Several of the ABFE setup exercises were causing issues on the server due to high memory usage. This PR converts those exercises into examples (which aren't run). I've cleaned the notebook and regenerated the markdown. Note that one of the cells setting up input files is still run, but this consistently ran without issues on the server during testing. Thanks.